### PR TITLE
Id

### DIFF
--- a/lib/api/generic/id.rb
+++ b/lib/api/generic/id.rb
@@ -1,0 +1,16 @@
+require 'http'
+
+module IPFS
+  class Client
+    def self.id
+      begin
+        JSON.parse HTTP.get 'http://localhost:5001/api/v0/id'
+      rescue HTTP::ConnectionError => e
+        {
+          "error" => e.message,
+          "description" => "Daemon is not running"
+        }
+      end
+    end
+  end
+end

--- a/lib/ipfs-api.rb
+++ b/lib/ipfs-api.rb
@@ -1,1 +1,1 @@
-require_relative './ipfs'
+require_relative './api/generic/id'

--- a/lib/ipfs.rb
+++ b/lib/ipfs.rb
@@ -1,5 +1,0 @@
-class IPFS
-  def self.id
-    'your id is not yet discoverable'
-  end
-end

--- a/spec/api/generic/id_spec.rb
+++ b/spec/api/generic/id_spec.rb
@@ -1,0 +1,71 @@
+require_relative '../../../lib/api/generic/id'
+
+describe IPFS::Client do
+  let(:node_id) { File.read File.join('spec', 'fixtures', 'id.json')  }
+  let(:uri) { 'http://localhost:5001/api/v0/id' }
+
+  it 'is an IPFS::Client' do
+    expect(described_class.new).to be_a IPFS::Client
+  end
+
+  describe '#id' do
+    context 'when daemon is started' do
+      before do
+        stub_request(:get, uri)
+          .to_return(
+            status: 200,
+            headers: { 'Content-Type': 'application/json' },
+            body: node_id
+          )
+      end
+
+      let!(:client_id) { described_class.id }
+
+      it 'calls the Ipfs API' do
+        expect(WebMock).to have_requested(:get, uri)
+      end
+
+      it 'hashes the response' do
+        expect(client_id).to be_a Hash
+      end
+
+      it 'has the correct ID' do
+        expect(client_id["ID"]).to eq JSON.parse(node_id)["ID"]
+      end
+
+      it 'has the correct PublicKey' do
+        expect(client_id["PublicKey"]).to eq JSON.parse(node_id)["PublicKey"]
+      end
+
+      it 'has the correct Addresses' do
+        expect(client_id["Addresses"])
+          .to contain_exactly *(JSON.parse(node_id)["Addresses"])
+      end
+
+      it 'has the correct AgentVersion' do
+        expect(client_id["AgentVersion"]).to eq JSON.parse(node_id)["AgentVersion"]
+      end
+
+      it 'has the correct PublicKey' do
+        expect(client_id["PublicKey"]).to eq JSON.parse(node_id)["PublicKey"]
+      end
+    end
+
+    context 'when daemon is not started' do
+      before do
+        stub_request(:get, uri)
+          .to_raise(HTTP::ConnectionError.new)
+      end
+
+      let!(:client_id) { described_class.id }
+
+      it 'fail to call the Ipfs API' do
+        expect(client_id).to include("error")
+      end
+
+      it 'has a response containing an error message' do
+        expect(client_id['description']).to eq "Daemon is not running"
+      end
+    end
+  end
+end

--- a/spec/fixtures/id_empty.json
+++ b/spec/fixtures/id_empty.json
@@ -1,2 +1,0 @@
-Error: no IPFS repo found in /root/.ipfs.
-please run: 'ipfs init'

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -30,6 +30,7 @@ RSpec.configure do |config|
     # ...rather than:
     #     # => "be bigger than 2"
     expectations.include_chain_clauses_in_custom_matcher_descriptions = true
+    expectations.syntax = :expect
   end
 
   # rspec-mocks config goes here. You can use an alternate test double

--- a/spec/test_spec.rb
+++ b/spec/test_spec.rb
@@ -1,5 +1,0 @@
-RSpec.describe "test" do
-  it "should be fine" do
-    expect(2).to eq 2
-  end
-end


### PR DESCRIPTION
It is a simple id command that is fault tolerant (.i.e does not fail if the daemon is not running)

It does not support requesting other node. That something will should implement later on (I made a Trello a card for that -> [card](https://trello.com/c/ZzDKlGKa)).

**The command is not yet decoupled from the client and thus should not be followed as an implementation rule for further commands.**

In order to have an architecture that support adding other commands I'll do my best to make the `version` command ASAP.