### PR TITLE
Architecture refactored

### DIFF
--- a/lib/api/generic/id.rb
+++ b/lib/api/generic/id.rb
@@ -1,12 +1,13 @@
-require_relative '../../client'
-
 module Ipfs
   module Command
     class Id
       PATH = '/id'
 
       def self.make_request
-        parse_response Client.call_api method: :get, path: PATH
+        {
+          method: :get,
+          path: PATH
+        }
       end
 
       def self.parse_response response

--- a/lib/api/generic/version.rb
+++ b/lib/api/generic/version.rb
@@ -6,7 +6,10 @@ module Ipfs
       PATH = '/version'
 
       def self.make_request
-        parse_response Client.call_api method: :get, path: PATH
+        {
+          method: :get,
+          path: PATH
+        }
       end
 
       def self.parse_response response

--- a/lib/ipfs-api.rb
+++ b/lib/ipfs-api.rb
@@ -4,7 +4,7 @@ require_relative './api/generic/version'
 
 module Ipfs
   def self.id
-    Command::Id.make_request
+    Command::Id.parse_response Client.call_api Command::Id.make_request
   end
 
   def self.version

--- a/lib/ipfs-api.rb
+++ b/lib/ipfs-api.rb
@@ -1,3 +1,4 @@
+require_relative './client'
 require_relative './api/generic/id'
 require_relative './api/generic/version'
 

--- a/lib/ipfs-api.rb
+++ b/lib/ipfs-api.rb
@@ -8,6 +8,6 @@ module Ipfs
   end
 
   def self.version
-    Command::Version.make_request
+    Command::Version.parse_response Client.call_api Command::Version.make_request
   end
 end

--- a/spec/api/generic/id_spec.rb
+++ b/spec/api/generic/id_spec.rb
@@ -7,6 +7,15 @@ describe Ipfs::Command::Id do
     expect(described_class::PATH).to eq '/id'
   end
 
+  describe '.make_request' do
+    let(:request) { described_class.make_request }
+
+    it 'returns a valid request' do
+      expect(request[:method]).to eq :get
+      expect(request[:path]).to eq described_class::PATH
+    end
+  end
+
   describe '.parse_response' do
     let(:response) { described_class.parse_response node_id }
 

--- a/spec/api/generic/version_spec.rb
+++ b/spec/api/generic/version_spec.rb
@@ -5,6 +5,15 @@ describe Ipfs::Command::Version do
     expect(described_class::PATH).to eq '/version'
   end
 
+  describe '.make_request' do
+    let(:request) { described_class.make_request }
+
+    it 'returns a valid request' do
+      expect(request[:method]).to eq :get
+      expect(request[:path]).to eq described_class::PATH
+    end
+  end
+
   describe '.parse_response' do
     let(:node_version) { File.read File.join('spec', 'fixtures', 'version.json')  }
     let(:response) { described_class.parse_response node_version }

--- a/spec/ipfs-api_spec.rb
+++ b/spec/ipfs-api_spec.rb
@@ -1,0 +1,15 @@
+require_relative '../lib/ipfs-api'
+
+RSpec.describe Ipfs do
+  describe '.id' do
+    it 'respond to id' do
+      expect(Ipfs).to respond_to(:id).with(0).arguments
+    end
+  end
+
+  describe '.version' do
+    it 'respond to version' do
+      expect(Ipfs).to respond_to(:version).with(0).arguments
+    end
+  end
+end


### PR DESCRIPTION
# API call & Response Parsing moved to Ipfs module

This allow a much more easier testing of `Ipfs::Command::*.make_request` methods.

Since both actions are no more coupled to an api call, requests can no be tested simply as method output.